### PR TITLE
Add release.(yml) Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish
+      run: |
+        pwsh -Command "Publish-Module -Path ./NetboxPS -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }}"


### PR DESCRIPTION
It will push on PSGallery module when release a new version !

You need to add PSGALLERY_API_KEY secrets on GITHUB settings for this repo (you need to create a another on PS Gallery and generate the token) 