### PR TITLE
Fixing Interface Type parameter

### DIFF
--- a/Functions/DCIM/Interfaces/Add-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Add-NetboxDCIMInterface.ps1
@@ -1,5 +1,6 @@
 ﻿
-function Add-NetboxDCIMInterface {
+function Add-NetboxDCIMInterface
+{
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param
@@ -9,6 +10,9 @@ function Add-NetboxDCIMInterface {
 
         [Parameter(Mandatory = $true)]
         [string]$Name,
+
+        [ValidateSet('virtual', 'bridge', 'lag', '100base-tx', '1000base-t', '2.5gbase-t', '5gbase-t', '10gbase-t', '10gbase-cx4', '1000base-x-gbic', '1000base-x-sfp', '10gbase-x-sfpp', '10gbase-x-xfp', '10gbase-x-xenpak', '10gbase-x-x2', '25gbase-x-sfp28', '50gbase-x-sfp56', '40gbase-x-qsfpp', '50gbase-x-sfp28', '100gbase-x-cfp', '100gbase-x-cfp2', '200gbase-x-cfp2', '100gbase-x-cfp4', '100gbase-x-cpak', '100gbase-x-qsfp28', '200gbase-x-qsfp56', '400gbase-x-qsfpdd', '400gbase-x-osfp', '1000base-kx', '10gbase-kr', '10gbase-kx4', '25gbase-kr', '40gbase-kr4', '50gbase-kr', '100gbase-kp4', '100gbase-kr2', '100gbase-kr4', 'ieee802.11a', 'ieee802.11g', 'ieee802.11n', 'ieee802.11ac', 'ieee802.11ad', 'ieee802.11ax', 'ieee802.11ay', 'ieee802.15.1', 'other-wireless', 'gsm', 'cdma', 'lte', 'sonet-oc3', 'sonet-oc12', 'sonet-oc48', 'sonet-oc192', 'sonet-oc768', 'sonet-oc1920', 'sonet-oc3840', '1gfc-sfp', '2gfc-sfp', '4gfc-sfp', '8gfc-sfpp', '16gfc-sfpp', '32gfc-sfp28', '64gfc-qsfpp', '128gfc-qsfp28', 'infiniband-sdr', 'infiniband-ddr', 'infiniband-qdr', 'infiniband-fdr10', 'infiniband-fdr', 'infiniband-edr', 'infiniband-hdr', 'infiniband-ndr', 'infiniband-xdr', 't1', 'e1', 't3', 'e3', 'xdsl', 'docsis', 'gpon', 'xg-pon', 'xgs-pon', 'ng-pon2', 'epon', '10g-epon', 'cisco-stackwise', 'cisco-stackwise-plus', 'cisco-flexstack', 'cisco-flexstack-plus', 'cisco-stackwise-80', 'cisco-stackwise-160', 'cisco-stackwise-320', 'cisco-stackwise-480', 'juniper-vcp', 'extreme-summitstack', 'extreme-summitstack-128', 'extreme-summitstack-256', 'extreme-summitstack-512', 'other', IgnoreCase = $true)]
+        [string]$Type,
 
         [bool]$Enabled,
 
@@ -34,24 +38,30 @@ function Add-NetboxDCIMInterface {
         [uint16[]]$Tagged_VLANs
     )
 
-    if (-not [System.String]::IsNullOrWhiteSpace($Mode)) {
-        $PSBoundParameters.Mode = switch ($Mode) {
-            'Access' {
+    if (-not [System.String]::IsNullOrWhiteSpace($Mode))
+    {
+        $PSBoundParameters.Mode = switch ($Mode)
+        {
+            'Access'
+            {
                 100
                 break
             }
 
-            'Tagged' {
+            'Tagged'
+            {
                 200
                 break
             }
 
-            'Tagged All' {
+            'Tagged All'
+            {
                 300
                 break
             }
 
-            default {
+            default
+            {
                 $_
             }
         }

--- a/Functions/DCIM/Interfaces/Add-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Add-NetboxDCIMInterface.ps1
@@ -1,6 +1,5 @@
 ﻿
-function Add-NetboxDCIMInterface
-{
+function Add-NetboxDCIMInterface {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param
@@ -38,30 +37,24 @@ function Add-NetboxDCIMInterface
         [uint16[]]$Tagged_VLANs
     )
 
-    if (-not [System.String]::IsNullOrWhiteSpace($Mode))
-    {
-        $PSBoundParameters.Mode = switch ($Mode)
-        {
-            'Access'
-            {
+    if (-not [System.String]::IsNullOrWhiteSpace($Mode)) {
+        $PSBoundParameters.Mode = switch ($Mode) {
+            'Access' {
                 100
                 break
             }
 
-            'Tagged'
-            {
+            'Tagged' {
                 200
                 break
             }
 
-            'Tagged All'
-            {
+            'Tagged All' {
                 300
                 break
             }
 
-            default
-            {
+            default {
                 $_
             }
         }

--- a/Functions/DCIM/Interfaces/Get-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NetboxDCIMInterface.ps1
@@ -1,5 +1,6 @@
 ﻿
-function Get-NetboxDCIMInterface {
+function Get-NetboxDCIMInterface
+{
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param
@@ -25,7 +26,8 @@ function Get-NetboxDCIMInterface {
 
         [uint16]$Device_Id,
 
-        [uint16]$Type,
+        [ValidateSet('virtual', 'bridge', 'lag', '100base-tx', '1000base-t', '2.5gbase-t', '5gbase-t', '10gbase-t', '10gbase-cx4', '1000base-x-gbic', '1000base-x-sfp', '10gbase-x-sfpp', '10gbase-x-xfp', '10gbase-x-xenpak', '10gbase-x-x2', '25gbase-x-sfp28', '50gbase-x-sfp56', '40gbase-x-qsfpp', '50gbase-x-sfp28', '100gbase-x-cfp', '100gbase-x-cfp2', '200gbase-x-cfp2', '100gbase-x-cfp4', '100gbase-x-cpak', '100gbase-x-qsfp28', '200gbase-x-qsfp56', '400gbase-x-qsfpdd', '400gbase-x-osfp', '1000base-kx', '10gbase-kr', '10gbase-kx4', '25gbase-kr', '40gbase-kr4', '50gbase-kr', '100gbase-kp4', '100gbase-kr2', '100gbase-kr4', 'ieee802.11a', 'ieee802.11g', 'ieee802.11n', 'ieee802.11ac', 'ieee802.11ad', 'ieee802.11ax', 'ieee802.11ay', 'ieee802.15.1', 'other-wireless', 'gsm', 'cdma', 'lte', 'sonet-oc3', 'sonet-oc12', 'sonet-oc48', 'sonet-oc192', 'sonet-oc768', 'sonet-oc1920', 'sonet-oc3840', '1gfc-sfp', '2gfc-sfp', '4gfc-sfp', '8gfc-sfpp', '16gfc-sfpp', '32gfc-sfp28', '64gfc-qsfpp', '128gfc-qsfp28', 'infiniband-sdr', 'infiniband-ddr', 'infiniband-qdr', 'infiniband-fdr10', 'infiniband-fdr', 'infiniband-edr', 'infiniband-hdr', 'infiniband-ndr', 'infiniband-xdr', 't1', 'e1', 't3', 'e3', 'xdsl', 'docsis', 'gpon', 'xg-pon', 'xgs-pon', 'ng-pon2', 'epon', '10g-epon', 'cisco-stackwise', 'cisco-stackwise-plus', 'cisco-flexstack', 'cisco-flexstack-plus', 'cisco-stackwise-80', 'cisco-stackwise-160', 'cisco-stackwise-320', 'cisco-stackwise-480', 'juniper-vcp', 'extreme-summitstack', 'extreme-summitstack-128', 'extreme-summitstack-256', 'extreme-summitstack-512', 'other', IgnoreCase = $true)]
+        [string]$Type,
 
         [uint16]$LAG_Id,
 
@@ -34,7 +36,8 @@ function Get-NetboxDCIMInterface {
         [switch]$Raw
     )
 
-    process {
+    process
+    {
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters

--- a/Functions/DCIM/Interfaces/Get-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NetboxDCIMInterface.ps1
@@ -1,6 +1,5 @@
 ﻿
-function Get-NetboxDCIMInterface
-{
+function Get-NetboxDCIMInterface {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param
@@ -36,8 +35,7 @@ function Get-NetboxDCIMInterface
         [switch]$Raw
     )
 
-    process
-    {
+    process {
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters

--- a/Functions/DCIM/Interfaces/Set-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NetboxDCIMInterface.ps1
@@ -1,5 +1,6 @@
 ﻿
-function Set-NetboxDCIMInterface {
+function Set-NetboxDCIMInterface
+{
     [CmdletBinding(ConfirmImpact = 'Medium',
         SupportsShouldProcess = $true)]
     [OutputType([pscustomobject])]
@@ -16,6 +17,9 @@ function Set-NetboxDCIMInterface {
         [bool]$Enabled,
 
         [object]$Form_Factor,
+
+        [ValidateSet('virtual', 'bridge', 'lag', '100base-tx', '1000base-t', '2.5gbase-t', '5gbase-t', '10gbase-t', '10gbase-cx4', '1000base-x-gbic', '1000base-x-sfp', '10gbase-x-sfpp', '10gbase-x-xfp', '10gbase-x-xenpak', '10gbase-x-x2', '25gbase-x-sfp28', '50gbase-x-sfp56', '40gbase-x-qsfpp', '50gbase-x-sfp28', '100gbase-x-cfp', '100gbase-x-cfp2', '200gbase-x-cfp2', '100gbase-x-cfp4', '100gbase-x-cpak', '100gbase-x-qsfp28', '200gbase-x-qsfp56', '400gbase-x-qsfpdd', '400gbase-x-osfp', '1000base-kx', '10gbase-kr', '10gbase-kx4', '25gbase-kr', '40gbase-kr4', '50gbase-kr', '100gbase-kp4', '100gbase-kr2', '100gbase-kr4', 'ieee802.11a', 'ieee802.11g', 'ieee802.11n', 'ieee802.11ac', 'ieee802.11ad', 'ieee802.11ax', 'ieee802.11ay', 'ieee802.15.1', 'other-wireless', 'gsm', 'cdma', 'lte', 'sonet-oc3', 'sonet-oc12', 'sonet-oc48', 'sonet-oc192', 'sonet-oc768', 'sonet-oc1920', 'sonet-oc3840', '1gfc-sfp', '2gfc-sfp', '4gfc-sfp', '8gfc-sfpp', '16gfc-sfpp', '32gfc-sfp28', '64gfc-qsfpp', '128gfc-qsfp28', 'infiniband-sdr', 'infiniband-ddr', 'infiniband-qdr', 'infiniband-fdr10', 'infiniband-fdr', 'infiniband-edr', 'infiniband-hdr', 'infiniband-ndr', 'infiniband-xdr', 't1', 'e1', 't3', 'e3', 'xdsl', 'docsis', 'gpon', 'xg-pon', 'xgs-pon', 'ng-pon2', 'epon', '10g-epon', 'cisco-stackwise', 'cisco-stackwise-plus', 'cisco-flexstack', 'cisco-flexstack-plus', 'cisco-stackwise-80', 'cisco-stackwise-160', 'cisco-stackwise-320', 'cisco-stackwise-480', 'juniper-vcp', 'extreme-summitstack', 'extreme-summitstack-128', 'extreme-summitstack-256', 'extreme-summitstack-512', 'other', IgnoreCase = $true)]
+        [string]$Type,
 
         [uint16]$MTU,
 
@@ -37,33 +41,42 @@ function Set-NetboxDCIMInterface {
         [uint16[]]$Tagged_VLANs
     )
 
-    begin {
-        if (-not [System.String]::IsNullOrWhiteSpace($Mode)) {
-            $PSBoundParameters.Mode = switch ($Mode) {
-                'Access' {
+    begin
+    {
+        if (-not [System.String]::IsNullOrWhiteSpace($Mode))
+        {
+            $PSBoundParameters.Mode = switch ($Mode)
+            {
+                'Access'
+                {
                     100
                     break
                 }
 
-                'Tagged' {
+                'Tagged'
+                {
                     200
                     break
                 }
 
-                'Tagged All' {
+                'Tagged All'
+                {
                     300
                     break
                 }
 
-                default {
+                default
+                {
                     $_
                 }
             }
         }
     }
 
-    process {
-        foreach ($InterfaceId in $Id) {
+    process
+    {
+        foreach ($InterfaceId in $Id)
+        {
             $CurrentInterface = Get-NetboxDCIMInterface -Id $InterfaceId -ErrorAction Stop
 
             $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces', $CurrentInterface.Id))
@@ -72,13 +85,15 @@ function Set-NetboxDCIMInterface {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $pscmdlet.ShouldProcess("Interface ID $($CurrentInterface.Id)", "Set")) {
+            if ($Force -or $pscmdlet.ShouldProcess("Interface ID $($CurrentInterface.Id)", "Set"))
+            {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH
             }
         }
     }
 
-    end {
+    end
+    {
 
     }
 }

--- a/Functions/DCIM/Interfaces/Set-NetboxDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NetboxDCIMInterface.ps1
@@ -1,6 +1,5 @@
 ﻿
-function Set-NetboxDCIMInterface
-{
+function Set-NetboxDCIMInterface {
     [CmdletBinding(ConfirmImpact = 'Medium',
         SupportsShouldProcess = $true)]
     [OutputType([pscustomobject])]
@@ -41,42 +40,33 @@ function Set-NetboxDCIMInterface
         [uint16[]]$Tagged_VLANs
     )
 
-    begin
-    {
-        if (-not [System.String]::IsNullOrWhiteSpace($Mode))
-        {
-            $PSBoundParameters.Mode = switch ($Mode)
-            {
-                'Access'
-                {
+    begin {
+        if (-not [System.String]::IsNullOrWhiteSpace($Mode)) {
+            $PSBoundParameters.Mode = switch ($Mode) {
+                'Access' {
                     100
                     break
                 }
 
-                'Tagged'
-                {
+                'Tagged' {
                     200
                     break
                 }
 
-                'Tagged All'
-                {
+                'Tagged All' {
                     300
                     break
                 }
 
-                default
-                {
+                default {
                     $_
                 }
             }
         }
     }
 
-    process
-    {
-        foreach ($InterfaceId in $Id)
-        {
+    process {
+        foreach ($InterfaceId in $Id) {
             $CurrentInterface = Get-NetboxDCIMInterface -Id $InterfaceId -ErrorAction Stop
 
             $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces', $CurrentInterface.Id))
@@ -85,15 +75,13 @@ function Set-NetboxDCIMInterface
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $pscmdlet.ShouldProcess("Interface ID $($CurrentInterface.Id)", "Set"))
-            {
+            if ($Force -or $pscmdlet.ShouldProcess("Interface ID $($CurrentInterface.Id)", "Set")) {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH
             }
         }
     }
 
-    end
-    {
+    end {
 
     }
 }


### PR DESCRIPTION
Add-NetboxDCIMInterface, Get-NetboxDCIMInterface, and Set-NetboxDCIMInterface now use the -Type parameter correctly for the latest API.

I have included ValidateSet for the parameter

It probably should be made mandatory, but I didn't want to break any use of -Form_Factor with older APIs. One caveat to this is I had to switch -Type from a `uint16` to `string` variable type ing Get-NetboxDCIMInterface , so It may be breaking if this is how older APIs used it.